### PR TITLE
Correct bug. Change the assay to correct as the default from the object.

### DIFF
--- a/R/RunCanek.R
+++ b/R/RunCanek.R
@@ -5,7 +5,7 @@
 #' @param x object with expression counts or list of matrices.
 #' @param batches for S4 objects the column containing batch information.
 #' @param slot slot used for Seurat objects (default: data).
-#' @param assay assay used for Seurat objects (default: RNA).
+#' @param assay assay used for Seurat objects.
 #' @param features optional vector of features to use for correction.
 #' @param selection.method method used for FindVariableFeatures on Seurat objects when features is NULL.
 #' @param nfeatures  number of features returned by SelectIntegrationFeatures.

--- a/R/RunCanek.R
+++ b/R/RunCanek.R
@@ -24,7 +24,13 @@ RunCanek <- function(x, ...) {
 
 #' @rdname RunCanek
 #' @export
-RunCanek.Seurat <- function(x, batches = NULL, slot = "data", assay = "RNA", features = NULL, selection.method = "vst", nfeatures = 2000, fvf.nfeatures = 2000, integration.name = "Canek", debug = FALSE, ...) {
+RunCanek.Seurat <- function(x, batches = NULL, slot = "data", assay = NULL, features = NULL, selection.method = "vst", nfeatures = 2000, fvf.nfeatures = 2000, integration.name = "Canek", debug = FALSE, ...) {
+
+  #if not assay is selected, we used the default one
+  if(is.null(assay)){
+    assay <- Seurat::DefaultAssay(x)
+  }
+
   Seurat::DefaultAssay(x) <- assay
   obj <- Seurat::DietSeurat(x, counts = TRUE, data = TRUE, scale.data = FALSE, assays = assay, misc = FALSE)
   Seurat::VariableFeatures(obj) <- NULL

--- a/man/Canek-package.Rd
+++ b/man/Canek-package.Rd
@@ -12,6 +12,7 @@ Non-linear/linear hybrid method for batch-effect correction that uses Mutual Nea
 Useful links:
 \itemize{
   \item \url{https://martinloza.github.io/Canek/}
+  \item Report bugs at \url{https://github.com/MartinLoza/Canek/issues}
 }
 
 }

--- a/man/RunCanek.Rd
+++ b/man/RunCanek.Rd
@@ -13,7 +13,7 @@ RunCanek(x, ...)
   x,
   batches = NULL,
   slot = "data",
-  assay = "RNA",
+  assay = NULL,
   features = NULL,
   selection.method = "vst",
   nfeatures = 2000,
@@ -43,7 +43,7 @@ RunCanek(x, ...)
 
 \item{slot}{slot used for Seurat objects (default: data).}
 
-\item{assay}{assay used for Seurat objects (default: RNA).}
+\item{assay}{assay used for Seurat objects.}
 
 \item{features}{optional vector of features to use for correction.}
 


### PR DESCRIPTION
Using the RNA assay as default could create problems when the data was normalized in a different assay and the user doesn't specify the normalized assay. The change in code will solve this problem by using the default assay when the assay is not specified in the input parameters.  